### PR TITLE
Use scaled gallery images, load full size on click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public
+static/processed_images

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -51,4 +51,18 @@ window.addEventListener('DOMContentLoaded', event => {
         });
     });
 
+    // Only load full-resolution images when the gallery item is opened
+    document.querySelectorAll('.gallery-item').forEach(item => {
+        item.addEventListener('click', () => {
+            const index = item.id.substring('gallery-item'.length);
+            const image = document.querySelector(`img#work${index}`);
+            if (image !== null) {
+               const fullSrc = image.getAttribute('data-fullsrc')
+               image.setAttribute('src', fullSrc);
+            } else {
+                console.error(`Gallery image ${index} not found`);
+            }
+        });
+    });
 });
+

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -5,7 +5,7 @@
 */
 //
 // Scripts
-// 
+//
 
 window.addEventListener('DOMContentLoaded', event => {
 
@@ -23,7 +23,7 @@ window.addEventListener('DOMContentLoaded', event => {
 
     };
 
-    // Shrink the navbar 
+    // Shrink the navbar
     navbarShrink();
 
     // Shrink the navbar when page is scrolled
@@ -57,8 +57,8 @@ window.addEventListener('DOMContentLoaded', event => {
             const index = item.id.substring('gallery-item'.length);
             const image = document.querySelector(`img#work${index}`);
             if (image !== null) {
-               const fullSrc = image.getAttribute('data-fullsrc')
-               image.setAttribute('src', fullSrc);
+                const fullSrc = image.getAttribute('data-fullsrc')
+                image.setAttribute('src', fullSrc);
             } else {
                 console.error(`Gallery image ${index} not found`);
             }

--- a/templates/index.html
+++ b/templates/index.html
@@ -140,7 +140,7 @@
                 </div>
               </div>
               {% set scaled_img = resize_image(path=work.src, width=300, height=300, format="jpg") %}
-              <img class="img-fluid"  src="{{scaled_img.url}}" alt="{{work.alt}}" />
+              <img class="img-fluid" src="{{scaled_img.url}}" alt="{{work.alt}}" />
             </div>
           </div>
           {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,6 +125,7 @@
           <!-- Gallery Item {{loop.index}}-->
           <div class="col-md-6 col-lg-4">
             <div
+              id="gallery-item{{loop.index}}"
               class="gallery-item mx-auto"
               data-bs-toggle="modal"
               data-bs-target="#galleryModal{{loop.index}}"
@@ -138,7 +139,8 @@
                   <i class="fas fa-plus fa-3x"></i>
                 </div>
               </div>
-              <img class="img-fluid" src="{{work.src}}" alt="{{work.alt}}" />
+              {% set scaled_img = resize_image(path=work.src, width=300, height=300, format="jpg") %}
+              <img class="img-fluid"  src="{{scaled_img.url}}" alt="{{work.alt}}" />
             </div>
           </div>
           {% endfor %}
@@ -250,6 +252,7 @@
 
       <!-- Gallery Modals-->
       {% for work in works %}
+      {% set scaled_img = resize_image(path=work.src, width=300, height=300, format="jpg") %}
       <!-- Gallery Modal {{loop.index}}-->
       <div
         class="gallery-modal modal fade"
@@ -274,8 +277,10 @@
                   <div class="col-lg-8">
                     <!-- Gallery Modal - Image-->
                     <img
+                      id="work{{loop.index}}"
                       class="img-fluid rounded mb-5"
-                      src="{{work.src}}"
+                      src="{{scaled_img.url}}"
+                      data-fullsrc="{{work.src}}"
                       alt="{{work.alt}}"
                       title="{{work.alt}}"
                     />


### PR DESCRIPTION
 #2 Use Zola image scaling to reduce image size on the main gallery view, swap in the full-size version on-click. Unfortunately using `display: none` on the gallery images doesn't stop them from loading, but this approach seems to work well enough.